### PR TITLE
Adds the ability to customize the AvroMapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 //Settings
 ext {
     project_group = 'com.github.huntersherms'
-    project_version = '0.0.2'
+    project_version = '0.0.3'
     project_jdk = '1.8'
     project_pom = {
         name 'Pojo2Parquet'
@@ -39,7 +39,7 @@ version = project_version
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
 buildscript {
-    ext.kotlin_version = '1.1.4-2'
+    ext.kotlin_version = '1.1.4-3'
 
     repositories {
         mavenCentral()

--- a/src/main/kotlin/com/github/huntersherms/pojo2parquet/Pojo2Parquet.kt
+++ b/src/main/kotlin/com/github/huntersherms/pojo2parquet/Pojo2Parquet.kt
@@ -74,9 +74,10 @@ class Pojo2Parquet<T>(private val clazz: Class<T>) {
 
     /**
      * Use in place of pojos2Parquet if your POJOs are Jackson annotated and you want the derived parquet column names
-     * to follow your annotations rather than your POJO property names.
+     * to follow your annotations rather than your POJO property names, or optionally provide your own AvroMapper with
+     * your own configuration in place.
      */
-    fun jacksonAnnotatedPojos2Parquet(pojos: Collection<T>): File {
+    fun jacksonAnnotatedPojos2Parquet(pojos: Collection<T>, mapper: AvroMapper = getAvroMapper()): File {
 
         assert(pojos.isNotEmpty())
 
@@ -114,7 +115,7 @@ class Pojo2Parquet<T>(private val clazz: Class<T>) {
      * Use in place of parquet2Pojos if your POJOs are Jackson annotated and you want Jackson to manage the mapping
      * to your POJOs.
      */
-    fun parquet2JacksonAnnotatedPojos(file: File): List<T> {
+    fun parquet2JacksonAnnotatedPojos(file: File, mapper: AvroMapper = getAvroMapper()): List<T> {
 
         val mapper = AvroMapper()
 
@@ -146,6 +147,17 @@ class Pojo2Parquet<T>(private val clazz: Class<T>) {
                 })
 
         return pojos
+    }
+
+    /**
+     * Get an AvroMapper meeting the requirements of these Jackson methods. Useful if you want to set some default properties on
+     * your mapper such as defaulting to snake case.
+     *
+     * mapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+     */
+    fun getAvroMapper(): AvroMapper {
+
+        return AvroMapper(AvroFactory().enable(AvroGenerator.Feature.AVRO_FILE_OUTPUT))
     }
 
     /**

--- a/src/test/kotlin/com/github/huntersherms/pojo2parquet/Pojo2ParquetTest.kt
+++ b/src/test/kotlin/com/github/huntersherms/pojo2parquet/Pojo2ParquetTest.kt
@@ -1,10 +1,14 @@
 package com.github.huntersherms.pojo2parquet
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.dataformat.avro.AvroGenerator
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class Pojo2ParquetTest {
+
+    private val readerWriter = Pojo2Parquet(CrewMember::class.java)
 
     private val firefly = mutableListOf(
             CrewMember("Malcolm", "Reynolds", 49),
@@ -14,8 +18,6 @@ class Pojo2ParquetTest {
 
     @Test
     fun pojos2ParquetTestIAndOut() {
-
-        val readerWriter = Pojo2Parquet(CrewMember::class.java)
 
         val file = readerWriter.pojos2Parquet(firefly)
         file.deleteOnExit()
@@ -28,14 +30,18 @@ class Pojo2ParquetTest {
     @Test
     fun jacksonAnnotatedPojo2ParquetTestIAndOut() {
 
-        val readerWriter = Pojo2Parquet(CrewMember::class.java)
-
         val file = readerWriter.jacksonAnnotatedPojos2Parquet(firefly)
         file.deleteOnExit()
 
         val pojos = readerWriter.parquet2JacksonAnnotatedPojos(file)
 
         assertEquals(firefly, pojos)
+    }
+
+    @Test
+    fun getAvroMapperForcesFileInput() {
+
+        assertTrue(readerWriter.getAvroMapper().factory.isEnabled(AvroGenerator.Feature.AVRO_FILE_OUTPUT))
     }
 }
 


### PR DESCRIPTION
This enables more functionality, like providing POJOs that aren't necessarily Jackson annotated but still do conversions such as camelCase to snake_case:

```Java
val p2p: Pojo2Parquet<DTO> = Pojo2Parquet(dtoClass))
val mapper = p2p
        .getAvroMapper()
        .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE) as AvroMapper
p2p.jacksonAnnotatedPojos2Parquet(data, mapper)
```