### PR TITLE
Bug fix: Ignoring passed in mapper.

### DIFF
--- a/src/main/kotlin/com/github/huntersherms/pojo2parquet/Pojo2Parquet.kt
+++ b/src/main/kotlin/com/github/huntersherms/pojo2parquet/Pojo2Parquet.kt
@@ -83,12 +83,6 @@ class Pojo2Parquet<T>(private val clazz: Class<T>) {
 
         val file = File.createTempFile("parquet", ".gzip")
 
-        /*
-         * Constructs our Avro Mapper. For more info on the added configuration see:
-         * https://github.com/FasterXML/jackson-dataformats-binary/issues/15
-         */
-        val mapper = AvroMapper(AvroFactory().enable(AvroGenerator.Feature.AVRO_FILE_OUTPUT))
-
         //Derive our schema using Jackson
         val schema = getAvroSchema(mapper)
 
@@ -116,8 +110,6 @@ class Pojo2Parquet<T>(private val clazz: Class<T>) {
      * to your POJOs.
      */
     fun parquet2JacksonAnnotatedPojos(file: File, mapper: AvroMapper = getAvroMapper()): List<T> {
-
-        val mapper = AvroMapper()
 
         //Derive our schema using Jackson
         val schema = getAvroSchema(mapper)

--- a/src/test/kotlin/com/github/huntersherms/pojo2parquet/Pojo2ParquetTest.kt
+++ b/src/test/kotlin/com/github/huntersherms/pojo2parquet/Pojo2ParquetTest.kt
@@ -11,9 +11,9 @@ class Pojo2ParquetTest {
     private val readerWriter = Pojo2Parquet(CrewMember::class.java)
 
     private val firefly = mutableListOf(
-            CrewMember("Malcolm", "Reynolds", 49),
-            CrewMember("Zoe", "Washburne", 33),
-            CrewMember("Kaylee", "Frye", null)
+            CrewMember("Malcolm", "Reynolds", 49, 1234567890),
+            CrewMember("Zoe", "Washburne", 33, 2345678901),
+            CrewMember("Kaylee", "Frye", null, 3456789012)
     )
 
     @Test
@@ -47,4 +47,5 @@ class Pojo2ParquetTest {
 
 data class CrewMember(@get:JsonProperty("first_name") val firstName: String = "",
                       @get:JsonProperty("last_name") val lastName: String = "",
-                      @get:JsonProperty("age") val age: Int? = null)
+                      @get:JsonProperty("age") val age: Int? = null,
+                      @get:JsonProperty("id") val id: Long? = null)


### PR DESCRIPTION
I explicitly added the option to pass in an object mapper of your own creation, then proceeded to ignore that value. 🤕 